### PR TITLE
Add colors array as input for first test

### DIFF
--- a/spec/display_rainbow_spec.rb
+++ b/spec/display_rainbow_spec.rb
@@ -1,9 +1,11 @@
 describe '#display_rainbow' do
   it 'accepts one argument' do
+    colors = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
+
     allow(self).to receive(:puts)
 
-    expect { display_rainbow([]) }.to_not raise_error(NoMethodError)
-    expect { display_rainbow([]) }.to_not raise_error(ArgumentError)
+    expect { display_rainbow(colors) }.to_not raise_error(NoMethodError)
+    expect { display_rainbow(colors) }.to_not raise_error(ArgumentError)
   end
 
   it 'prints out the colors of the rainbow correctly when passed in in order' do


### PR DESCRIPTION
Some students are not hardcoding the capital letters for the output
and are instead doing `colors[0][0].capitalize`. While this
does technically work, it fails the tests if the input array is
empty.

@PeterBell 
